### PR TITLE
chore: add ovoscope end2end intent-routing tests

### DIFF
--- a/.github/workflows/ovoscope.yml
+++ b/.github/workflows/ovoscope.yml
@@ -13,5 +13,6 @@ jobs:
       python_version: '3.11'
       install_extras: 'test'
       require_padatious: true
+      require_adapt: true
       system_deps: 'swig libfann-dev'
       test_path: 'test/end2end/'

--- a/test/end2end/test_intents_en_us.py
+++ b/test/end2end/test_intents_en_us.py
@@ -23,9 +23,9 @@ class TestFusterIntentsEnUS(unittest.TestCase):
     def tearDownClass(cls):
         cls.minicroft.stop()
 
-    def _run(self, text):
+    def _run(self, text, pipeline=None):
         session = Session("test-session")
-        session.pipeline = [
+        session.pipeline = pipeline or [
             "ovos-padatious-pipeline-plugin-high",
             "ovos-padatious-pipeline-plugin-medium",
         ]
@@ -38,6 +38,13 @@ class TestFusterIntentsEnUS(unittest.TestCase):
         capture.capture(utterance, timeout=30)
         return capture.finish()
 
+    def _run_adapt(self, text):
+        return self._run(text, pipeline=[
+            "ovos-adapt-pipeline-plugin-high",
+            "ovos-adapt-pipeline-plugin-medium",
+            "ovos-adapt-pipeline-plugin-low",
+        ])
+
     def test_fuster_quote(self):
         messages = self._run("tell me a fuster quote")
         types = [m.msg_type for m in messages]
@@ -48,4 +55,22 @@ class TestFusterIntentsEnUS(unittest.TestCase):
         messages = self._run("who was Joan Fuster")
         types = [m.msg_type for m in messages]
         self.assertIn(f"{SKILL_ID}:who.intent", types)
+        self.assertTrue(any("speak" in t for t in types))
+
+    def test_fuster_live(self):
+        messages = self._run_adapt("when was Fuster alive")
+        types = [m.msg_type for m in messages]
+        self.assertIn(f"{SKILL_ID}:FusterLive", types)
+        self.assertTrue(any("speak" in t for t in types))
+
+    def test_fuster_birth(self):
+        messages = self._run_adapt("when was Joan Fuster born")
+        types = [m.msg_type for m in messages]
+        self.assertIn(f"{SKILL_ID}:FusterBirth", types)
+        self.assertTrue(any("speak" in t for t in types))
+
+    def test_fuster_death(self):
+        messages = self._run_adapt("when did Joan Fuster die")
+        types = [m.msg_type for m in messages]
+        self.assertIn(f"{SKILL_ID}:FusterDeath", types)
         self.assertTrue(any("speak" in t for t in types))


### PR DESCRIPTION
Auto-generated ovoscope intent-routing tests.

Covers Padatious intents (exact message-type assertions) and Adapt intents
(speak-response assertions). One test method per canonical utterance.

Generated by `tools/gen_ovoscope_tests.py` from the dataset at
`knowledge/datasets/ovoscope/test_dataset.jsonl`.

Run: `pytest test/end2end/ -v --timeout=60`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end coverage for several intent-handling scenarios, including additional spoken-response checks.
  * Added support for running these scenarios through an alternate intent pipeline in test coverage.

* **Chores**
  * Updated the automated workflow configuration to include an extra validation requirement for end-to-end test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->